### PR TITLE
Fixed custom booster's outline showing non-existent texture.

### DIFF
--- a/Code/FrostHelper/Entities/Booster/GenericCustomBooster.cs
+++ b/Code/FrostHelper/Entities/Booster/GenericCustomBooster.cs
@@ -190,7 +190,8 @@ namespace FrostHelper.Entities.Boosters {
 
         public override void Added(Scene scene) {
             base.Added(scene);
-            Image image = new Image(GFX.Game[$"{Directory.AsSpan().TrimEnd('/')}/outline"]);
+            string str = $"{Directory.AsSpan().TrimEnd('/')}/outline";
+            Image image = new Image(GFX.Game[GFX.Game.Has(str) ? str : "objects/booster/outline"]);
             image.CenterOrigin();
             image.Color = Color.White * 0.75f;
             outline = new Entity(Position) {


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/367dec1e-6bf5-471a-aeed-5a1d52f97cad)
