### PR TITLE
SpeedRingChallenge Playback Racers

### DIFF
--- a/Code/FrostHelper/Entities/SpeedRingChallenge.cs
+++ b/Code/FrostHelper/Entities/SpeedRingChallenge.cs
@@ -117,7 +117,7 @@ public class SpeedRingChallenge : Entity {
                     FinalTimeSpent = TimeSpent;
                     Finished = true;
                     Visible = false;
-                    //This is where the playback should stop
+                    StopPlayback();
 
                     FrostModule.SaveData.SetChallengeTime(SceneAs<Level>().Session.Area.SID, ChallengeNameID, FinalTimeSpent);
 
@@ -151,6 +151,13 @@ public class SpeedRingChallenge : Entity {
         if (playback is null) return;
         playback.Active = true;
         playback.Restart();
+    }
+
+    private void StopPlayback() {
+        if (playback is null) return;
+        if (playback.Visible)
+            Audio.Play("event:/new_content/char/tutorial_ghost/disappear", playback.Position);
+        playback.Active = playback.Visible = false;
     }
 
     public override void Render() {

--- a/Code/FrostHelper/Entities/SpeedRingChallenge.cs
+++ b/Code/FrostHelper/Entities/SpeedRingChallenge.cs
@@ -55,6 +55,7 @@ public class SpeedRingChallenge : Entity {
 
             if (playbackStartTrim < playback.TrimEnd && playbackStartTrim > 0) {
                 playback.TrimStart = playbackStartTrim;
+                playback.Restart();
             }
             playback.startDelay = 0f;
             playback.Active = false;

--- a/Code/FrostHelper/Entities/SpeedRingChallenge.cs
+++ b/Code/FrostHelper/Entities/SpeedRingChallenge.cs
@@ -1,4 +1,6 @@
-﻿namespace FrostHelper;
+﻿using FrostHelper.Helpers;
+
+namespace FrostHelper;
 
 [CustomEntity("FrostHelper/SpeedRingChallenge")]
 [Tracked]
@@ -36,11 +38,14 @@ public class SpeedRingChallenge : Entity {
         ArrowTextures = GFX.Game.GetAtlasSubtextures("util/dasharrow/dasharrow");
         string playbackName = data.Attr("playbackName");
         if (!string.IsNullOrWhiteSpace(playbackName)) {
-            var playbackData = PlaybackData.Tutorials[playbackName];
+            if (!PlaybackData.Tutorials.TryGetValue(playbackName, out var playbackData))
+                throw new InvalidOperationException($"Could not find playback data for {playbackName}");
             playback = new PlayerPlayback(Position, PlayerSpriteMode.Playback, playbackData);
             playback.startDelay = 0f;
             playback.Active = false;
             playback.Visible = false;
+            
+            
         }
 
         Depth = Depths.Top;

--- a/Code/FrostHelper/Entities/SpeedRingChallenge.cs
+++ b/Code/FrostHelper/Entities/SpeedRingChallenge.cs
@@ -22,6 +22,7 @@ public class SpeedRingChallenge : Entity {
     public Color RingColor;
     readonly List<MTexture> ArrowTextures;
     private PlayerPlayback? playback;
+    private Vector2 playbackOffset;
 
     public long TimeSpent => Finished ? FinalTimeSpent : Scene == null ? 0 : SceneAs<Level>().Session.Time - StartChapterTimer;
 
@@ -40,7 +41,8 @@ public class SpeedRingChallenge : Entity {
         if (!string.IsNullOrWhiteSpace(playbackName)) {
             if (!PlaybackData.Tutorials.TryGetValue(playbackName, out var playbackData))
                 throw new InvalidOperationException($"Could not find playback data for {playbackName}");
-            playback = new PlayerPlayback(Position, PlayerSpriteMode.Playback, playbackData);
+            playbackOffset = new Vector2(data.Float("playbackOffsetX", 0f), data.Float("playbackOffsetY", 0f));
+            playback = new PlayerPlayback(Position + playbackOffset, PlayerSpriteMode.Playback, playbackData);
             playback.startDelay = 0f;
             playback.Active = false;
             playback.Visible = false;

--- a/Code/FrostHelper/Entities/SpeedRingChallenge.cs
+++ b/Code/FrostHelper/Entities/SpeedRingChallenge.cs
@@ -21,6 +21,7 @@ public class SpeedRingChallenge : Entity {
     bool spawnBerry;
     public Color RingColor;
     readonly List<MTexture> ArrowTextures;
+    
     private PlayerPlayback? playback;
     private Vector2 playbackOffset;
 
@@ -37,12 +38,24 @@ public class SpeedRingChallenge : Entity {
         height = data.Height;
         spawnBerry = data.Bool("spawnBerry", true);
         ArrowTextures = GFX.Game.GetAtlasSubtextures("util/dasharrow/dasharrow");
+        //Playback creation begins
         string playbackName = data.Attr("playbackName");
         if (!string.IsNullOrWhiteSpace(playbackName)) {
             if (!PlaybackData.Tutorials.TryGetValue(playbackName, out var playbackData))
                 throw new InvalidOperationException($"Could not find playback data for {playbackName}");
+            //Positioning the playback if desired
             playbackOffset = new Vector2(data.Float("playbackOffsetX", 0f), data.Float("playbackOffsetY", 0f));
             playback = new PlayerPlayback(Position + playbackOffset, PlayerSpriteMode.Playback, playbackData);
+            //Trimming the playback if desired
+            float playbackStartTrim = data.Float("playbackStartTrim");
+            float playbackEndTrim = data.Float("playbackEndTrim");
+            if (playbackEndTrim < playback.TrimEnd && playbackStartTrim < playbackEndTrim && playbackEndTrim > 0) {
+                playback.TrimEnd = playbackEndTrim;
+            }
+
+            if (playbackStartTrim < playback.TrimEnd && playbackStartTrim > 0) {
+                playback.TrimStart = playbackStartTrim;
+            }
             playback.startDelay = 0f;
             playback.Active = false;
             playback.Visible = false;

--- a/Code/FrostHelper/Entities/SpeedRingChallenge.cs
+++ b/Code/FrostHelper/Entities/SpeedRingChallenge.cs
@@ -87,6 +87,7 @@ public class SpeedRingChallenge : Entity {
 
     public override void Update() {
         base.Update();
+        StopPlaybackIfAboutToLoop();
         Active = Visible = !Finished;
         if (!Finished && CollideCheck<Player>()) {
             if (!started) {
@@ -152,7 +153,6 @@ public class SpeedRingChallenge : Entity {
         playback.Active = true;
         playback.Restart();
     }
-
     private void StopPlayback() {
         if (playback is null) return;
         if (playback.Visible)
@@ -160,6 +160,11 @@ public class SpeedRingChallenge : Entity {
         playback.Active = playback.Visible = false;
     }
 
+    private void StopPlaybackIfAboutToLoop() {
+        if (playback is null || !playback.Active || playback.Visible) return;
+        StopPlayback();
+    } 
+    
     public override void Render() {
         base.Render();
         if (!(Scene as Level)!.Paused) {

--- a/Loenn/entities/speedChallenge.lua
+++ b/Loenn/entities/speedChallenge.lua
@@ -4,6 +4,7 @@ local jautils = require("mods").requireFromPlugin("libraries.jautils")
 local speedRingChallenge = {}
 speedRingChallenge.name = "FrostHelper/SpeedRingChallenge"
 speedRingChallenge.nodeLineRenderType = "line"
+speedRingChallenge.fieldOrder = {"x", "y", "width", "height", "timeLimit", "name", "playbackName"}
 speedRingChallenge.placements =
 {
     name = "normal",
@@ -12,6 +13,7 @@ speedRingChallenge.placements =
         height = 16,
         timeLimit = 1.0,
         name = "fh_test",
+        playbackName = "",
     }
 }
 

--- a/Loenn/entities/speedChallenge.lua
+++ b/Loenn/entities/speedChallenge.lua
@@ -4,7 +4,7 @@ local jautils = require("mods").requireFromPlugin("libraries.jautils")
 local speedRingChallenge = {}
 speedRingChallenge.name = "FrostHelper/SpeedRingChallenge"
 speedRingChallenge.nodeLineRenderType = "line"
-speedRingChallenge.fieldOrder = {"x", "y", "width", "height", "timeLimit", "name", "playbackName", "playbackOffsetX", "playbackOffsetY"}
+speedRingChallenge.fieldOrder = {"x", "y", "width", "height", "timeLimit", "name", "playbackName", "playbackOffsetX", "playbackOffsetY", "playbackStartTrim", "playbackEndTrim"}
 speedRingChallenge.placements =
 {
     name = "normal",
@@ -16,6 +16,8 @@ speedRingChallenge.placements =
         playbackName = "",
         playbackOffsetX = 0.0,
         playbackOffsetY = 0.0,
+        playbackStartTrim = 0.0,
+        playbackEndTrim = 0.0,
     }
 }
 

--- a/Loenn/entities/speedChallenge.lua
+++ b/Loenn/entities/speedChallenge.lua
@@ -4,7 +4,7 @@ local jautils = require("mods").requireFromPlugin("libraries.jautils")
 local speedRingChallenge = {}
 speedRingChallenge.name = "FrostHelper/SpeedRingChallenge"
 speedRingChallenge.nodeLineRenderType = "line"
-speedRingChallenge.fieldOrder = {"x", "y", "width", "height", "timeLimit", "name", "playbackName"}
+speedRingChallenge.fieldOrder = {"x", "y", "width", "height", "timeLimit", "name", "playbackName", "playbackOffsetX", "playbackOffsetY"}
 speedRingChallenge.placements =
 {
     name = "normal",
@@ -14,6 +14,8 @@ speedRingChallenge.placements =
         timeLimit = 1.0,
         name = "fh_test",
         playbackName = "",
+        playbackOffsetX = 0.0,
+        playbackOffsetY = 0.0,
     }
 }
 

--- a/Loenn/lang/en_gb.lang
+++ b/Loenn/lang/en_gb.lang
@@ -464,6 +464,7 @@ entities.FrostHelper/SpeedRingChallenge.attributes.description.name=The name of 
 entities.FrostHelper/SpeedRingChallenge.attributes.description.playbackName=Insert the name of a playback file to create a ghost playback that races the player.
 entities.FrostHelper/SpeedRingChallenge.attributes.description.playbackOffsetX=Moves the starting point of the playback racer
 entities.FrostHelper/SpeedRingChallenge.attributes.description.playbackOffsetY=Moves the starting point of the playback racer
+entities.FrostHelper/SpeedRingChallenge.attributes.description.playbackStartTrim=Sets how far into the playback it starts. May require changing the offset. 
 entities.FrostHelper/SpeedRingChallenge.attributes.description.playbackEndTrim=Sets how long the playback will play for. Does nothing if set to 0.
 
 entities.FrostHelper/RainbowTilesetController.placements.name.normal=Rainbow Tileset Controller

--- a/Loenn/lang/en_gb.lang
+++ b/Loenn/lang/en_gb.lang
@@ -461,6 +461,10 @@ entities.FrostHelper/ColoredLightbeam.attributes.description.flag=Session flag t
 entities.FrostHelper/SpeedRingChallenge.placements.name.normal=Speed Ring Challenge
 entities.FrostHelper/SpeedRingChallenge.attributes.description.timeLimit=How much time (in seconds) the player has to complete the challenge
 entities.FrostHelper/SpeedRingChallenge.attributes.description.name=The name of this challenge. Used for saving times
+entities.FrostHelper/SpeedRingChallenge.attributes.description.playbackName=Insert the name of a playback file to create a ghost playback that races the player.
+entities.FrostHelper/SpeedRingChallenge.attributes.description.playbackOffsetX=Moves the starting point of the playback racer
+entities.FrostHelper/SpeedRingChallenge.attributes.description.playbackOffsetY=Moves the starting point of the playback racer
+entities.FrostHelper/SpeedRingChallenge.attributes.description.playbackEndTrim=Sets how long the playback will play for. Does nothing if set to 0.
 
 entities.FrostHelper/RainbowTilesetController.placements.name.normal=Rainbow Tileset Controller
 entities.FrostHelper/RainbowTilesetController.attributes.description.bg=Whether this controller should affect BG tiles instead of FG tiles


### PR DESCRIPTION
Adds playback functionality (and associated fields and tooltips) to the SpeedRingChallenge entity to allow mappers to add ghost racers to the challenge.

(Sorry for any parts of this that look funny, this is my first C# and my first github pull request.)