### PR TITLE
Let beam follow player with extra angle offset to make cooler attack pattern

### DIFF
--- a/Code/FrostHelper/Entities/LuaBadelineBoss.cs
+++ b/Code/FrostHelper/Entities/LuaBadelineBoss.cs
@@ -661,6 +661,7 @@ public class CustomBossBeam : Entity {
         followTimer = args.GetOrDefault("followTime", 0.9f);
         chargeTimer = followTimer + args.GetOrDefault("lockTime", 0.5f);
         activeTimer = args.GetOrDefault("activeTime", 0.12f); // todo: fix
+        followTargetAngleOffset = args.GetOrDefault("followTargetAngleOffset", 0f).ToRad();
 
         beamSprite.Play("charge", false, false);
         sideFadeAlpha = 0f;
@@ -680,8 +681,6 @@ public class CustomBossBeam : Entity {
             chargeTimer -= followTimer;
             followTimer = 0;
         } else {
-            if (args?["followTargetAngleOffset"] is { })
-                followTargetAngleOffset = args.GetOrDefault("followTargetAngleOffset", float.MinValue).ToRad();
             Vector2 targetPosition = GetRotatedBeamTargetPosition(target.Center, followTargetAngleOffset);
             
             angle = Calc.Angle(boss.BeamOrigin, targetPosition);


### PR DESCRIPTION
<img width="2244" height="1316" alt="0744801b87df4e79d55be1c66c9f856c" src="https://github.com/user-attachments/assets/cb5fd5c8-056a-46cf-b527-ef1029066937" />

``` lua
 beam(
  {
      followTargetAngleOffset = 0,
  },
  {
      followTargetAngleOffset = 90,
  },
  {
      followTargetAngleOffset = 180,
  },
  {
      followTargetAngleOffset = 270,
  })
```


https://github.com/user-attachments/assets/d5611d7e-162d-458a-8b72-7d5aefaa89a3

